### PR TITLE
Implementing configurable error status code

### DIFF
--- a/BonCodeAJP13/BonCodeAJP13Enums.cs
+++ b/BonCodeAJP13/BonCodeAJP13Enums.cs
@@ -293,6 +293,9 @@ namespace BonCodeAJP13
         //fingerprint
         public static bool BONCODEAJP13_ENABLE_CLIENTFINGERPRINT = Properties.Settings.Default.EnableClientFingerPrint; // false
 
+        //error status code
+        public static int BONCODEAJP13_ERROR_STATUSCODE = Properties.Settings.Default.ErrorStatusCode;
+
     }  
 
 

--- a/BonCodeAJP13/Properties/Settings.Designer.cs
+++ b/BonCodeAJP13/Properties/Settings.Designer.cs
@@ -304,6 +304,22 @@ namespace BonCodeAJP13.Properties {
                 return ((bool)(this["EnableHTTPStatusCodes"]));
             }
         }
+
+        /// <summary>
+        /// Status code that is returned to IIS on connection failure, e.g. 500. Default: 200
+        /// </summary>
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(BonCodeAJP13.Config.BonCodeAJP13SettingProvider))]
+        [global::System.Configuration.SettingsDescriptionAttribute("Status code that is returned to IIS on connection failure, e.g. 500. Default: 200")]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("200")]
+        public int ErrorStatusCode
+        {
+            get
+            {
+                return ((int)(this["ErrorStatusCode"]));
+            }
+        }
         
         /// <summary>
         /// Message to be displayed to user if we experience issues with TCP client connections to Tomcat.

--- a/BonCodeIIS/CallHandler.cs
+++ b/BonCodeIIS/CallHandler.cs
@@ -515,7 +515,7 @@ namespace BonCodeIIS
         /// </summary>
         private void PrintError(HttpContext context, String strMsg, String strStacktrace)
         {
-            context.Response.StatusCode = 500;
+            context.Response.StatusCode = BonCodeAJP13Settings.BONCODEAJP13_ERROR_STATUSCODE;
             context.Response.Write(strMsg);
             if (IsLocalIP(GetKeyValue(context.Request.ServerVariables, "REMOTE_ADDR"))) {
                 context.Response.Write("<br><pre>" + strStacktrace + "</pre>");


### PR DESCRIPTION
#10 This pull request introduces a new setting `ErrorStatusCode`. Whenever the connector experiences any kind of connection error, the response status code is set to the value of this setting.

The default is 200 for backward compatibility. 
