### PR TITLE
Implementing configurable error status code

### DIFF
--- a/BonCodeAJP13/BonCodeAJP13Enums.cs
+++ b/BonCodeAJP13/BonCodeAJP13Enums.cs
@@ -293,6 +293,9 @@ namespace BonCodeAJP13
         //fingerprint
         public static bool BONCODEAJP13_ENABLE_CLIENTFINGERPRINT = Properties.Settings.Default.EnableClientFingerPrint; // false
 
+        //error status code
+        public static int BONCODEAJP13_ERROR_STATUSCODE = Properties.Settings.Default.ErrorStatusCode;
+
     }  
 
 

--- a/BonCodeAJP13/BonCodeAJP13ServerConnection.cs
+++ b/BonCodeAJP13/BonCodeAJP13ServerConnection.cs
@@ -783,6 +783,8 @@ namespace BonCodeAJP13
         /// </summary>
         private void ConnectionError()
         {
+            p_PacketsReceived.Add(new TomcatSendBodyChunk("<!-- tomcat-iis-connection-error -->"));
+
             if (p_Logger != null) p_Logger.LogMessage("One Connection raised an error", BonCodeAJP13LogLevels.BONCODEAJP13_LOG_ERRORS);
             //attempt to close stream
             try
@@ -810,6 +812,8 @@ namespace BonCodeAJP13
 
         private void ConnectionError(string message, string messageType)
         {
+            p_PacketsReceived.Add(new TomcatSendBodyChunk("<!-- tomcat-iis-connection-error -->"));
+
             if (p_Logger != null) p_Logger.LogMessageAndType(message, messageType, BonCodeAJP13LogLevels.BONCODEAJP13_LOG_ERRORS);
             //attempt to close stream
             try

--- a/BonCodeAJP13/Properties/Settings.Designer.cs
+++ b/BonCodeAJP13/Properties/Settings.Designer.cs
@@ -304,6 +304,22 @@ namespace BonCodeAJP13.Properties {
                 return ((bool)(this["EnableHTTPStatusCodes"]));
             }
         }
+
+        /// <summary>
+        /// Status code that is returned to IIS on connection failure, e.g. 500. Default: 200
+        /// </summary>
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(BonCodeAJP13.Config.BonCodeAJP13SettingProvider))]
+        [global::System.Configuration.SettingsDescriptionAttribute("Status code that is returned to IIS on connection failure, e.g. 500. Default: 200")]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("200")]
+        public int ErrorStatusCode
+        {
+            get
+            {
+                return ((int)(this["ErrorStatusCode"]));
+            }
+        }
         
         /// <summary>
         /// Message to be displayed to user if we experience issues with TCP client connections to Tomcat.

--- a/BonCodeAJP13/ServerPackets/BonCodeAJP13ForwardRequest.cs
+++ b/BonCodeAJP13/ServerPackets/BonCodeAJP13ForwardRequest.cs
@@ -309,7 +309,7 @@ namespace BonCodeAJP13.ServerPackets
             int packetFillBytes = 14; //bytes used to complete package
             int expectedPacketSize = 0;
 
-
+            FixNullEmptyHeaders(httpHeaders);
             NameValueCollection goodHeaders = CheckHeaders(httpHeaders); //determine headers to be transferred
             num_headers = goodHeaders.AllKeys.Length; 
             PopulateRawHeaders(httpHeaders["ALL_RAW"]); //we use this to do retranslate the spelling (case) of header names
@@ -523,6 +523,20 @@ namespace BonCodeAJP13.ServerPackets
 
 
             //BonCodeAJP13Logger.LogDebug(String.Format("FR521 {0} http{1}://{2}{3} {4} P-{5} [{6}]", remote_addr, is_ssl ? "s" : "", server_name, req_uri, GetKeyValue(httpHeaders, "QUERY_STRING"), sourcePort, PacketID));
+        }
+
+        /// <summary>
+        /// Takes any headers with a null value and sets their value to an empty string, avoiding the need for later null checking in multiple places
+        /// </summary>
+        private void FixNullEmptyHeaders(NameValueCollection httpHeaders)
+        {
+            for (int i = 0; i < httpHeaders.AllKeys.Length; i++)
+            {
+                if (httpHeaders[httpHeaders.AllKeys[i]] == null)
+                {
+                    httpHeaders[httpHeaders.AllKeys[i]] = "";
+                }
+            }
         }
 
 

--- a/BonCodeIIS/CallHandler.cs
+++ b/BonCodeIIS/CallHandler.cs
@@ -436,9 +436,16 @@ namespace BonCodeIIS
 
                     else if (flushPacket is TomcatSendBodyChunk)
                     {
-                        transferredBytes = transferredBytes + flushPacket.Length;
-                        if (flushPacket.Length > 0)
-                            context.Response.BinaryWrite(flushPacket.GetUserDataBytes());
+                        if (flushPacket.Length > 0) 
+                        {
+                            transferredBytes = transferredBytes + flushPacket.Length;
+
+                            if (flushPacket.GetDataString().Contains( "<!-- tomcat-iis-connection-error -->" ) )
+                                context.Response.StatusCode = BonCodeAJP13Settings.BONCODEAJP13_ERROR_STATUSCODE;
+                            else
+                                context.Response.BinaryWrite(flushPacket.GetUserDataBytes());
+                        }
+                            
 
                     }
                 }

--- a/BonCodeIIS/CallHandler.cs
+++ b/BonCodeIIS/CallHandler.cs
@@ -515,6 +515,7 @@ namespace BonCodeIIS
         /// </summary>
         private void PrintError(HttpContext context, String strMsg, String strStacktrace)
         {
+            context.Response.StatusCode = 500;
             context.Response.Write(strMsg);
             if (IsLocalIP(GetKeyValue(context.Request.ServerVariables, "REMOTE_ADDR"))) {
                 context.Response.Write("<br><pre>" + strStacktrace + "</pre>");

--- a/BonCodeIIS/CallHandler.cs
+++ b/BonCodeIIS/CallHandler.cs
@@ -515,7 +515,7 @@ namespace BonCodeIIS
         /// </summary>
         private void PrintError(HttpContext context, String strMsg, String strStacktrace)
         {
-            context.Response.StatusCode = 500;
+            context.Response.StatusCode = BonCodeAJP13Settings.BONCODEAJP13_ERROR_STATUSCODE;
             context.Response.Write(strMsg);
             if (IsLocalIP(GetKeyValue(context.Request.ServerVariables, "REMOTE_ADDR"))) {
                 context.Response.Write("<br><pre>" + strStacktrace + "</pre>");

--- a/BonCodeIIS/CallHandler.cs
+++ b/BonCodeIIS/CallHandler.cs
@@ -522,7 +522,11 @@ namespace BonCodeIIS
         /// </summary>
         private void PrintError(HttpContext context, String strMsg, String strStacktrace)
         {
-            context.Response.StatusCode = BonCodeAJP13Settings.BONCODEAJP13_ERROR_STATUSCODE;
+            if (strMsg.Length > 0 && context.Response.StatusCode >= 200 && context.Response.StatusCode < 300)
+            {
+                context.Response.StatusCode = BonCodeAJP13Settings.BONCODEAJP13_ERROR_STATUSCODE;
+            }
+
             context.Response.Write(strMsg);
             if (IsLocalIP(GetKeyValue(context.Request.ServerVariables, "REMOTE_ADDR"))) {
                 context.Response.Write("<br><pre>" + strStacktrace + "</pre>");

--- a/BonCodeIIS/CallHandler.cs
+++ b/BonCodeIIS/CallHandler.cs
@@ -152,7 +152,7 @@ namespace BonCodeIIS
                         else
                         {
                             string errMsg = "Error connecting to Apache Tomcat instance.<hr>Please check that a Tomcat server is running at given location and port..<br>Details:<br>" + e.Message + "<br><small><small><br>You can change this message by changing TomcatConnectErrorURL setting in setting file.</small></small>";
-                            PrintError(context, errMsg, e.StackTrace, true);
+                            PrintError(context, errMsg, e.StackTrace);
                         }
                         blnProceed = false;
 
@@ -265,7 +265,7 @@ namespace BonCodeIIS
                     {
                         //we have an error do the dump on screen since we are not logging but allso kill connection
                         string errMsg = "Generic Connector Communication Error: <hr>Please check and adjust your setup..<br>If this is a timeout error consider adjusting IIS timeout by changing executionTimeout attribute in web.config (see manual).";
-                        PrintError(context, errMsg, e.StackTrace, true);
+                        PrintError(context, errMsg, e.StackTrace);
                         KillConnection(); //remove TCP cache good after timeouts
                     }
 
@@ -453,7 +453,7 @@ namespace BonCodeIIS
                 {
                     //display error    
                     String errMsg = "Error in transfer of data from tomcat to browser.";
-                    PrintError(context, errMsg, e.StackTrace,false);
+                    PrintError(context, errMsg, e.StackTrace);
 
                 }
 
@@ -467,7 +467,7 @@ namespace BonCodeIIS
             catch (Exception e)
             {
                 //do nothing. Mostly this occurs if the browser already closed connection with server or headers were already transferred                
-                PrintError(context, "", e.StackTrace, false);
+                PrintError(context, "", e.StackTrace);
             }
 
             p_FlushInProgress = false;
@@ -520,7 +520,7 @@ namespace BonCodeIIS
         /// Determine if local call and print error on screen.
         /// TODO: This will be extended in the future to log errors to file.
         /// </summary>
-        private void PrintError(HttpContext context, String strMsg, String strStacktrace, Boolean setStatusCode)
+        private void PrintError(HttpContext context, String strMsg, String strStacktrace)
         {
             if (strMsg.Length > 0 && context.Response.StatusCode >= 200 && context.Response.StatusCode < 300)
             {

--- a/BonCodeIIS/CallHandler.cs
+++ b/BonCodeIIS/CallHandler.cs
@@ -152,8 +152,7 @@ namespace BonCodeIIS
                         else
                         {
                             string errMsg = "Error connecting to Apache Tomcat instance.<hr>Please check that a Tomcat server is running at given location and port..<br>Details:<br>" + e.Message + "<br><small><small><br>You can change this message by changing TomcatConnectErrorURL setting in setting file.</small></small>";
-                            context.Response.Write(errMsg);
-                            PrintError(context, e.StackTrace);
+                            PrintError(context, errMsg, e.StackTrace);
                         }
                         blnProceed = false;
 
@@ -265,9 +264,8 @@ namespace BonCodeIIS
                     catch (Exception e)
                     {
                         //we have an error do the dump on screen since we are not logging but allso kill connection
-                        string errMsg = "Generic Connector Communication Error: <hr>Please check and adjust your setup..<br>If this is a timeout error consider adjusting IIS timeout by changing executionTimeout attribute in web.config (see manual).<br>Details:<br>" + e.StackTrace + "";
-                        context.Response.Write(errMsg);
-                        PrintError(context, e.StackTrace);
+                        string errMsg = "Generic Connector Communication Error: <hr>Please check and adjust your setup..<br>If this is a timeout error consider adjusting IIS timeout by changing executionTimeout attribute in web.config (see manual).";
+                        PrintError(context, errMsg, e.StackTrace);
                         KillConnection(); //remove TCP cache good after timeouts
                     }
 
@@ -446,9 +444,9 @@ namespace BonCodeIIS
                 }
                 catch (Exception e)
                 {
-                    //display error                    
-                    context.Response.Write("Error in transfer of data from tomcat to browser.");
-                    PrintError(context, e.StackTrace);
+                    //display error    
+                    String errMsg = "Error in transfer of data from tomcat to browser.";
+                    PrintError(context, errMsg, e.StackTrace);
 
                 }
 
@@ -462,7 +460,7 @@ namespace BonCodeIIS
             catch (Exception e)
             {
                 //do nothing. Mostly this occurs if the browser already closed connection with server or headers were already transferred                
-                PrintError(context, e.StackTrace);
+                PrintError(context, "", e.StackTrace);
             }
 
             p_FlushInProgress = false;
@@ -515,10 +513,11 @@ namespace BonCodeIIS
         /// Determine if local call and print error on screen.
         /// TODO: This will be extended in the future to log errors to file.
         /// </summary>
-        private void PrintError(HttpContext context,String strErr)
+        private void PrintError(HttpContext context, String strMsg, String strStacktrace)
         {
+            context.Response.Write(strMsg);
             if (IsLocalIP(GetKeyValue(context.Request.ServerVariables, "REMOTE_ADDR"))) {
-                context.Response.Write("<br><pre>" + strErr + "</pre>");
+                context.Response.Write("<br><pre>" + strStacktrace + "</pre>");
             }
         }
 


### PR DESCRIPTION
Hi Bilal. This pull requests adds a configuration option `ErrorStatusCode`. When this option is set to 500, for example, any connection errors that happen get a 500 status code set on the response. This allows us to use IIS's error handling to deal with showing friendly errors, etc.

Some of the implementation is a little hacky. For instance, I could not figure how to craft a header packet to set the status code from within BonCodeAJP13ServerConnection.cs. Instead, I just added an HTML comment body chunk that the CallHandler.cs can detect and more easily set the status code.

It would be great if either this could be pulled in or something similar implemented.

Thanks for reading

Dominic