### PR TITLE
Fix PathPrefix bug.

### DIFF
--- a/BonCodeAJP13/ServerPackets/BonCodeAJP13ForwardRequest.cs
+++ b/BonCodeAJP13/ServerPackets/BonCodeAJP13ForwardRequest.cs
@@ -391,7 +391,8 @@ namespace BonCodeAJP13.ServerPackets
 
             //add a mapping prefix if one is provided unless the same prefix is already on the start of Uri (case sensitive comparison)
             if (BonCodeAJP13Settings.BONCODEAJP13_PATH_PREFIX.Length > 2
-                && !BonCodeAJP13Settings.BONCODEAJP13_PATH_PREFIX.Equals(req_uri.Substring(0, BonCodeAJP13Settings.BONCODEAJP13_PATH_PREFIX.Length - 1), StringComparison.Ordinal))
+                && (req_uri.Length < BonCodeAJP13Settings.BONCODEAJP13_PATH_PREFIX.Length
+                || !BonCodeAJP13Settings.BONCODEAJP13_PATH_PREFIX.Equals(req_uri.Substring(0, BonCodeAJP13Settings.BONCODEAJP13_PATH_PREFIX.Length - 1), StringComparison.Ordinal)))
             {                
                 req_uri = BonCodeAJP13Settings.BONCODEAJP13_PATH_PREFIX + req_uri;
             }


### PR DESCRIPTION
When a request is made where the URI string length is shorter than the string length of the PathPrefix value the following exception gets thrown:

`Index and length must refer to a location within the string.
Parameter name: length    at System.String.Substring(Int32 startIndex, Int32 length)
   at BonCodeAJP13.ServerPackets.BonCodeAJP13ForwardRequest.WritePacket(Byte method, String protocol, String req_uri, String remote_addr, String remote_host, String server_name, UInt16 server_port, Boolean is_ssl, Int32 num_headers, NameValueCollection httpHeaders, String realPathInfo, Int32 sourcePort, String vDirs)
   at BonCodeAJP13.ServerPackets.BonCodeAJP13ForwardRequest.WritePacket(NameValueCollection httpHeaders, String pathInfo, Int32 sourcePort, String vDirs)
   at BonCodeIIS.BonCodeCallHandler.ProcessRequest(HttpContext context)`

This pull request resolves that bug.