### PR TITLE
Check in changes to Support the Project and allow for none Standerd …

### DIFF
--- a/BonCodeAJP13/BonCodeAJP13Enums.cs
+++ b/BonCodeAJP13/BonCodeAJP13Enums.cs
@@ -141,6 +141,7 @@ namespace BonCodeAJP13
         public const byte BONCODEAJP13_MERGE = 0x19;            // MERGE 25 
         public const byte BONCODEAJP13_BASELINE_CONTROL = 0x1A; // BASELINE_CONTROL 26 
         public const byte BONCODEAJP13_MKACTIVITY = 0x1B;       // MKACTIVITY 27 
+        public const byte BONCODEAJP13_SC_M_JKSTORED = 0xFF;       // Any other VERB 255 to Stroe in Attributes
 
     }
 
@@ -166,6 +167,7 @@ namespace BonCodeAJP13
        public const byte BONCODEAJP13_REQ_ATTRIBUTE = 0x0A;    // ?req_attribute 0x0A Name (the name of the attribut follows). This one will be used to send named attribute pairs
        public const byte BONCODEAJP13_SSL_KEY_SIZE = 0x0B;     // ?ssl_key_size 0x0B  
        public const byte BONCODEAJP13_SECRET = 0x0C;           // ?secret -- request secret needs to match requiredSecret on Tomcat AJP connection defintion in server.xml
+       public const byte BONCODEAJP13_STORED_METHOD = 0x0D;    // Used to handle non Default HTTP Methods
        public const byte BONCODEAJP13_ACCEPT = 0xFF;           // are_done 0xFF request_terminator. This one is appended automatically to packet.
 
     }

--- a/BonCodeAJP13/BonCodeAJP13PacketHeaders.cs
+++ b/BonCodeAJP13/BonCodeAJP13PacketHeaders.cs
@@ -105,9 +105,10 @@ namespace BonCodeAJP13
             /// </summary> 
             public static byte GetMethodByte(string methodKey)
             {
-                byte retVal = BonCodeAJP13HTTPMethods.BONCODEAJP13_GET;
+            //Change the Default from "BONCODEAJP13_GET" to "BONCODEAJP13_SC_M_JKSTORED",  This will allow us to check and Store the VERB in the BONCODEAJP13_STORED_METHOD Attribute
+            byte retVal = BonCodeAJP13HTTPMethods.BONCODEAJP13_SC_M_JKSTORED;  
 
-                if (p_MStringTranslator.ContainsKey(methodKey))
+            if (p_MStringTranslator.ContainsKey(methodKey))
                 {
                     retVal = (byte)p_MStringTranslator[methodKey];
                 }

--- a/BonCodeAJP13/ServerPackets/BonCodeAJP13ForwardRequest.cs
+++ b/BonCodeAJP13/ServerPackets/BonCodeAJP13ForwardRequest.cs
@@ -566,8 +566,17 @@ namespace BonCodeAJP13.ServerPackets
                     }
                 }
             }
-            
+
             //WRITE NAMED ATTRIBUTES
+
+
+            //Check if the METHOD needs to be sent in the STORED METHOD Attribute IF SO we Set that Attribute and Value
+            if (method == BonCodeAJP13HTTPMethods.BONCODEAJP13_SC_M_JKSTORED)
+            {
+                string NonStandardVerb = GetKeyValue(httpHeaders, "REQUEST_METHOD");
+                pos = SetByte(aUserData, BonCodeAJP13HTTPAttributes.BONCODEAJP13_STORED_METHOD, pos); //attribute marker
+                pos = SetString(aUserData, NonStandardVerb, pos);  //method: e.g. we have clicked on URL
+            }
 
 
             //add secure session attribute


### PR DESCRIPTION
This is to support the Patch and other none Default verbs.  They must be sent as attributes since the AJP13 process does not have a byte configuration for that method.  Instead you sent them as Method byte 255 and then add the attribute with the value of the verb.  I have confirmed this working in my systems.   This is a fix for Issue Http Verb Issue #40