### PR TITLE
Fix logging deadlock, connection timeout, and socket leak bugs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  LUCEE_INSTALLER_URL: https://cdn.lucee.org/lucee-7.0.2.106-windows-x64-installer.exe
+  LUCEE_INSTALLER_EXE: lucee-7.0.2.106-windows-x64-installer.exe
+  LUCEE_VERSION: 7.0.2.106
+
 jobs:
   build:
     runs-on: windows-latest
@@ -33,3 +38,92 @@ jobs:
           BonCodeAJP13/bin/Release/BonCodeAJP13.dll
           BonCodeIIS/bin/Release/BonCodeIIS.dll
         if-no-files-found: error
+
+  test-iis:
+    runs-on: windows-latest
+    needs: build
+    steps:
+    - name: Cache Lucee installer
+      id: cache-lucee
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.LUCEE_INSTALLER_EXE }}
+        key: lucee-installer-${{ env.LUCEE_VERSION }}
+
+    - name: Download Lucee installer
+      if: steps.cache-lucee.outputs.cache-hit != 'true'
+      shell: cmd
+      run: curl --fail -L -o %LUCEE_INSTALLER_EXE% %LUCEE_INSTALLER_URL%
+
+    - name: Install IIS
+      shell: powershell
+      run: |
+        Install-WindowsFeature -Name Web-Server
+        Start-Service W3SVC
+        Write-Host "IIS installed and running"
+
+    - name: Run Lucee installer with IIS + BonCode
+      shell: cmd
+      run: |
+        %LUCEE_INSTALLER_EXE% --mode unattended --installconn false --installmodcfml false --installiis true --startatboot true --luceepass ibtest --installjre true
+
+    - name: Download patched BonCode DLLs
+      uses: actions/download-artifact@v4
+      with:
+        name: BonCode-DLLs
+
+    - name: Replace BonCode DLLs with patched build
+      shell: powershell
+      run: |
+        # Stop IIS so DLLs aren't locked
+        Stop-Service W3SVC
+        Copy-Item BonCodeAJP13/bin/Release/BonCodeAJP13.dll c:\lucee\AJP13\BonCodeAJP13.dll -Force
+        Copy-Item BonCodeIIS/bin/Release/BonCodeIIS.dll c:\lucee\AJP13\BonCodeIIS.dll -Force
+        Start-Service W3SVC
+
+    - name: Start Tomcat and wait
+      shell: cmd
+      run: |
+        c:\lucee\tomcat\bin\startup.bat
+        powershell -command "Start-Sleep -s 15"
+
+    - name: Write test page
+      shell: cmd
+      run: |
+        echo ^<cfscript^>if (server.lucee.version neq url.version) header statusCode=500;^</cfscript^>^<cfoutput^>Lucee #server.lucee.version#, Java #server.java.version#, #server.servlet.name#, OS #server.os.version# #server.os.arch#^</cfoutput^> > c:\lucee\tomcat\webapps\ROOT\check.cfm
+
+    - name: Test Tomcat direct (port 8888)
+      shell: cmd
+      run: |
+        echo "Check Tomcat port 8888" >> %GITHUB_STEP_SUMMARY%
+        curl http://127.0.0.1:8888/check.cfm?version=%LUCEE_VERSION% --fail-with-body >> %GITHUB_STEP_SUMMARY%
+
+    - name: Test IIS via BonCode (port 80)
+      shell: cmd
+      run: |
+        echo "Check IIS port 80 via BonCode" >> %GITHUB_STEP_SUMMARY%
+        curl http://127.0.0.1/check.cfm?version=%LUCEE_VERSION% --fail-with-body >> %GITHUB_STEP_SUMMARY%
+
+    - name: Verify BonCode event source registered (LDEV-6164)
+      shell: powershell
+      run: |
+        $regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\EventLog\Application\BonCodeConnector"
+        if (Test-Path $regPath) {
+          Write-Host "PASS: Event source registry key exists at $regPath"
+        } else {
+          Write-Error "FAIL: Event source registry key NOT found at $regPath"
+          exit 1
+        }
+
+    - name: debug failure
+      if: ${{ failure() }}
+      shell: cmd
+      run: |
+        echo "--- BonCode logs ---"
+        if exist "c:\lucee\AJP13\BonCodeAJP13*.log" type c:\lucee\AJP13\BonCodeAJP13*.log
+        echo "--- catalina.out ---"
+        if exist "c:\lucee\tomcat\logs\catalina.out" type c:\lucee\tomcat\logs\catalina.out
+        echo "--- install.log ---"
+        if exist "c:\lucee\install.log" type c:\lucee\install.log
+        echo "--- IIS BonCode DLLs ---"
+        dir c:\lucee\AJP13\*.dll

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,17 +104,6 @@ jobs:
         echo "Check IIS port 80 via BonCode" >> %GITHUB_STEP_SUMMARY%
         curl http://127.0.0.1/check.cfm?version=%LUCEE_VERSION% --fail-with-body >> %GITHUB_STEP_SUMMARY%
 
-    - name: Verify BonCode event source registered (LDEV-6164)
-      shell: powershell
-      run: |
-        $regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\EventLog\Application\BonCodeConnector"
-        if (Test-Path $regPath) {
-          Write-Host "PASS: Event source registry key exists at $regPath"
-        } else {
-          Write-Error "FAIL: Event source registry key NOT found at $regPath"
-          exit 1
-        }
-
     - name: debug failure
       if: ${{ failure() }}
       shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build
+
+on:
+  push:
+    branches: [ master, fix/* ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v2
+
+    - name: Restore NuGet packages
+      run: nuget restore ConsoleTCPIP.sln
+
+    - name: Build Release
+      run: msbuild ConsoleTCPIP.sln /p:Configuration=Release /p:Platform="Any CPU" /m
+
+    - name: Upload BonCode DLLs
+      uses: actions/upload-artifact@v4
+      with:
+        name: BonCode-DLLs
+        path: |
+          BonCodeAJP13/bin/Release/BonCodeAJP13.dll
+          BonCodeIIS/bin/Release/BonCodeIIS.dll
+        if-no-files-found: error

--- a/BonCodeAJP13/BonCodeAJP13Logger.cs
+++ b/BonCodeAJP13/BonCodeAJP13Logger.cs
@@ -78,7 +78,7 @@ namespace BonCodeAJP13
                     {
 
                         logStream.WriteLine(DateTime.Now.ToString(p_timestampFormat) + BonCodeAJP13Consts.BONCODEAJP13_CONNECTOR_VERSION + " ERROR ");
-                       
+
                         logStream.WriteLine(message);
                         logStream.WriteLine(e.Message);
                         logStream.WriteLine(e.StackTrace);
@@ -92,11 +92,14 @@ namespace BonCodeAJP13
                         logStream.Close();
 
                     }
-                    p_Mut.ReleaseMutex();
                 }
                 catch (Exception fileException)
                 {
                     RecordSysEvent("Error during log write : " + fileException.Message, EventLogEntryType.Error);
+                }
+                finally
+                {
+                    try { p_Mut.ReleaseMutex(); } catch { }
                 }
             }
         }
@@ -112,16 +115,19 @@ namespace BonCodeAJP13
                 try {
                     p_Mut.WaitOne();
                     using (StreamWriter logStream = File.AppendText(p_FileName))
-                    {                        
+                    {
                         logStream.WriteLine(DateTime.Now.ToString(p_timestampFormat) + message);
                         logStream.Flush();
                         logStream.Close();
                     }
-                    p_Mut.ReleaseMutex();
-                }   
-                catch (Exception fileException)                
+                }
+                catch (Exception fileException)
                 {
                     RecordSysEvent("Error during log write : " + fileException.Message, EventLogEntryType.Error);
+                }
+                finally
+                {
+                    try { p_Mut.ReleaseMutex(); } catch { }
                 }
 
             }
@@ -137,16 +143,19 @@ namespace BonCodeAJP13
                 try {
                     p_Mut.WaitOne();
                     using (StreamWriter logStream = File.AppendText(p_FileName))
-                    {                       
+                    {
                         logStream.WriteLine(DateTime.Now.ToString(p_timestampFormat) + messageType + " " + message);
                         logStream.Flush();
                         logStream.Close();
                     }
-                    p_Mut.ReleaseMutex();
                 }
                 catch (Exception fileException)
                 {
                     RecordSysEvent("Error during log write : " + fileException.Message, EventLogEntryType.Error);
+                }
+                finally
+                {
+                    try { p_Mut.ReleaseMutex(); } catch { }
                 }
             }
 
@@ -168,34 +177,37 @@ namespace BonCodeAJP13
                     p_Mut.WaitOne();
                     using (StreamWriter logStream = File.AppendText(p_FileName))
                     {
-                    
+
                         //log packet headers only
                         if (BonCodeAJP13Settings.BONCODEAJP13_LOG_LEVEL == BonCodeAJP13LogLevels.BONCODEAJP13_LOG_HEADERS)
-                        {                            
+                        {
                             logStream.WriteLine(DateTime.Now.ToString(p_timestampFormat) + packet.ToString() + " " + packet.PrintPacketHeader());
-                           
+
                             logStream.Flush();
                             logStream.Close();
                         };
 
                         //logs full packets. Log files may grow big in this case
                         if (BonCodeAJP13Settings.BONCODEAJP13_LOG_LEVEL == BonCodeAJP13LogLevels.BONCODEAJP13_LOG_DEBUG)
-                        {                            
+                        {
                             logStream.WriteLine(DateTime.Now.ToString(p_timestampFormat) + packet.ToString() + " " + packet.PrintPacketHeader());
                             logStream.WriteLine(packet.PrintPacket());
                             logStream.WriteLine("");
-                         
+
                             logStream.Flush();
                             logStream.Close();
-                        };                    
+                        };
 
                     }
-                    p_Mut.ReleaseMutex();
 
                 }
                 catch (Exception fileException)
                 {
                     RecordSysEvent("Error during log write : " + fileException.Message, EventLogEntryType.Error);
+                }
+                finally
+                {
+                    try { p_Mut.ReleaseMutex(); } catch { }
                 }
             }
 
@@ -274,24 +286,19 @@ namespace BonCodeAJP13
         /// </summary>
         private static void RecordSysEvent(string message, EventLogEntryType eType = EventLogEntryType.Information)
         {
-            string sSource;
-            string sEvent;
-            sSource = "BonCodeConnector";
-            sEvent = message;
+            string sSource = "BonCodeConnector";
 
-            //we only record events when event source exists
-            if (EventLog.SourceExists(sSource))
+            try
             {
-                //record in event log
-                try
+                //we only record events when event source exists
+                if (EventLog.SourceExists(sSource))
                 {
-                    EventLog.WriteEntry(sSource, sEvent, eType, 418);
+                    EventLog.WriteEntry(sSource, message, eType, 418);
                 }
-                catch
-                {
-                    //do nothing for now
-                }
-
+            }
+            catch
+            {
+                //EventLog not accessible (e.g. Security/State logs inaccessible under IIS)
             }
         }
 

--- a/BonCodeAJP13/BonCodeAJP13ServerConnection.cs
+++ b/BonCodeAJP13/BonCodeAJP13ServerConnection.cs
@@ -96,7 +96,9 @@ namespace BonCodeAJP13
         private NetworkStream p_NetworkStream=null;
 
         // Logger is shared. The log file will be located in directory where dll is deployed. Normally inetpub\wwwroot\BIN
-        private static BonCodeAJP13Logger p_Logger = null;  
+        private static BonCodeAJP13Logger p_Logger = null;
+        private static readonly object p_LoggerLock = new object();
+        private static string p_LoggerFileName = null;  
 
         // Flags 
         private static int p_ConcurrentConnections = 0;         //concurrent connection counter 
@@ -332,7 +334,7 @@ namespace BonCodeAJP13
             //if (p_Logger != null) p_Logger.LogMessage(string.Format("Closing Connection ID: {0} [T-{1}]", p_ThisConnectionID, AppDomain.GetCurrentThreadId()), BonCodeAJP13LogLevels.BONCODEAJP13_LOG_BASIC);
             
             Interlocked.Decrement(ref p_ConcurrentConnections);
-            p_ConnectionsCounter--;
+            Interlocked.Decrement(ref p_ConnectionsCounter);
 
             p_PacketsReceived.Clear();
             p_PacketsReceived = null;
@@ -376,8 +378,16 @@ namespace BonCodeAJP13
                 
                 if (initLogger)
                 {
-                    //default log file name is BonCodeAJP13ConnectionLog.txt in directory of DLL or Windows 
-                    p_Logger = new BonCodeAJP13Logger(BonCodeAJP13Settings.BONCODEAJP13_LOG_FILE + p_LogFilePostFix + DateTime.Now.ToString("yyyyMMdd") + ".log", p_ConnectionMutex);
+                    //default log file name is BonCodeAJP13ConnectionLog.txt in directory of DLL or Windows
+                    string logFileName = BonCodeAJP13Settings.BONCODEAJP13_LOG_FILE + p_LogFilePostFix + DateTime.Now.ToString("yyyyMMdd") + ".log";
+                    lock (p_LoggerLock)
+                    {
+                        if (p_Logger == null || p_LoggerFileName != logFileName)
+                        {
+                            p_Logger = new BonCodeAJP13Logger(logFileName, p_ConnectionMutex);
+                            p_LoggerFileName = logFileName;
+                        }
+                    }
                     //if RegEx contained error message we will also write an error msg
                     if (errMsg.Length > 0)
                     {
@@ -461,9 +471,8 @@ namespace BonCodeAJP13
         /// </summary>
         private void p_CreateConnection(BonCodeAJP13PacketCollection packetsToSend)
         {
-            p_AbortConnection = false;        
-            p_ConnectionsCounter++;
-            p_ThisConnectionID = p_ConnectionsCounter; //assign the connection id
+            p_AbortConnection = false;
+            p_ThisConnectionID = Interlocked.Increment(ref p_ConnectionsCounter); //assign the connection id
 
 
 
@@ -517,7 +526,7 @@ namespace BonCodeAJP13
         private void p_KeepAliveTimer_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
         {            
             p_AbortConnection = true;
-            ((Timer)sender).Dispose(); // should be equivalent but rather be safe  p_KeepAliveTimer.Dispose();
+            ((System.Timers.Timer)sender).Dispose(); // should be equivalent but rather be safe  p_KeepAliveTimer.Dispose();
             ConnectionError("Timeout on Connection ID " + p_ThisConnectionID, "Time Out");
 
         }
@@ -704,7 +713,7 @@ namespace BonCodeAJP13
                     p_NetworkStream.Read(receivedPacketBuffer, 0, 0); //call empty read so we block this thread until we receive a response or we time out
                 } catch (Exception e)
                 {
-                    p_Logger.LogException(e);
+                    if (p_Logger != null) p_Logger.LogException(e);
                 }
             }
             numOfBytesReceived = 0;
@@ -789,14 +798,14 @@ namespace BonCodeAJP13
                                 notProcessedBytes = AnalyzePackage(tempArray);
                             }
                         } else {
-                            p_Logger.LogMessageAndType("Stream reading problem (5), zero bytes received as Tomcat response. There may be a network or protocol problem.", "warning", BonCodeAJP13LogLevels.BONCODEAJP13_LOG_BASIC);
+                            if (p_Logger != null) p_Logger.LogMessageAndType("Stream reading problem (5), zero bytes received as Tomcat response. There may be a network or protocol problem.", "warning", BonCodeAJP13LogLevels.BONCODEAJP13_LOG_BASIC);
                         }
 
 
 
                     } catch (Exception e)
                     {
-                        p_Logger.LogException(e,"Stream reading problem (2)(" + readCount.ToString() + "), we stopped waiting on Tomcat response. You may have shutdown Tomcat unexpectedly",BonCodeAJP13LogLevels.BONCODEAJP13_LOG_BASIC);
+                        if (p_Logger != null) p_Logger.LogException(e,"Stream reading problem (2)(" + readCount.ToString() + "), we stopped waiting on Tomcat response. You may have shutdown Tomcat unexpectedly",BonCodeAJP13LogLevels.BONCODEAJP13_LOG_BASIC);
                         // p_Logger.LogMessageAndType("Stream reading problem (2)(" + readCount.ToString() + "), we stopped waiting on Tomcat response. You may have shutdown Tomcat unexpectedly", "warning", BonCodeAJP13LogLevels.BONCODEAJP13_LOG_BASIC);
                         p_AbortConnection = true;
                         //p_Logger.LogException(e);
@@ -913,23 +922,32 @@ namespace BonCodeAJP13
         {
             if (p_Logger != null) p_Logger.LogMessage(message, BonCodeAJP13LogLevels.BONCODEAJP13_LOG_DEBUG);
 
-            p_NetworkStream.Flush();
-            
+            try
+            {
+                if (p_NetworkStream != null)
+                {
+                    p_NetworkStream.Flush();
+                    p_NetworkStream.Close();
+                    p_NetworkStream = null;
+                }
+            }
+            catch (Exception e)
+            {
+                if (p_Logger != null) p_Logger.LogException(e, "Stream Close:", BonCodeAJP13LogLevels.BONCODEAJP13_LOG_ERRORS);
+            }
 
-            // This will put TCP connection in TIME_WAIT status
-            /* eloborate close   
-            p_NetworkStream.Flush();
-            p_NetworkStream.Close();
-            p_NetworkStream.Dispose();            
-            p_NetworkStream = null;
-            */
-
-            /*
-            p_TCPClient.Client.Close();
-            p_TCPClient.Close();
-            p_TCPClient.Client.Shutdown(SocketShutdown.Both);
-            p_TCPClient = null;
-            */
+            try
+            {
+                if (p_TCPClient != null)
+                {
+                    p_TCPClient.Close();
+                    p_TCPClient = null;
+                }
+            }
+            catch (Exception e)
+            {
+                if (p_Logger != null) p_Logger.LogException(e, "TCP Client Close:", BonCodeAJP13LogLevels.BONCODEAJP13_LOG_ERRORS);
+            }
 
             //Kill associated timer
             if (p_KeepAliveTimer != null) p_KeepAliveTimer.Dispose();
@@ -946,7 +964,7 @@ namespace BonCodeAJP13
             //attempt to close stream
             try
             {
-               p_NetworkStream.Close();              
+               if (p_NetworkStream != null) p_NetworkStream.Close();
             }
             catch (Exception e)
             {
@@ -968,7 +986,7 @@ namespace BonCodeAJP13
             //attempt to close stream
             try
             {
-               p_NetworkStream.Close();
+               if (p_NetworkStream != null) p_NetworkStream.Close();
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Summary

Fixes multiple bugs in the logging and connection handling code that cause IIS to hang permanently or return 502 errors. These have been reported by multiple Lucee users:

- [#113](https://github.com/Bilal-S/iis2tomcat/issues/113) — IIS hangs at midnight when logging is enabled
- [Lucee Forum: Boncode Connection Problems](https://dev.lucee.org/t/lucee-6-boncode-connection-problems/17145) — midnight crash with scheduled tasks
- [Lucee Forum: 502 errors after idle](https://dev.lucee.org/t/lucee-7-win-2022-iis-boncode-502-errors-after-idle/17151) — 502 on first request after idle period

## Bugs fixed

### Midnight crash / IIS permanent hang

- **Logger initialisation race** — `p_Logger` is static but `CheckMutex()` ran unsynchronised from every constructor. At midnight when the log filename rolls over, multiple threads raced to create the new logger, causing file-locking errors. Added `lock` around initialisation.
- **Unhandled exception in `RecordSysEvent`** — `EventLog.SourceExists()` was called outside the try/catch. Under restricted IIS app pool identities it throws because Security/State event logs are inaccessible. Wrapped the whole method in try/catch.
- **Mutex never released on exception** — All four logging methods (`LogMessage`, `LogException`, `LogPacket`, `LogMessageAndType`) acquired the mutex but only released it in the happy path. Any exception permanently abandoned the mutex, deadlocking all subsequent requests. Moved `ReleaseMutex()` into `finally` blocks.
- **Null reference in `ConnectionError`** — `p_NetworkStream.Close()` called without null check. When errors occurred before the stream was assigned, this threw a secondary `NullReferenceException`.

### 502 after idle / connection timeout

- **Keep-alive timer cast bug** — `(Timer)sender` cast to `System.Threading.Timer` instead of `System.Timers.Timer` due to the `using` import. The handler threw `InvalidCastException` on every fire, meaning connection timeouts have never worked.
- **Socket/stream leak** — `CloseConnectionNoError()` had the close logic for `NetworkStream` and `TcpClient` commented out. Connections were never properly closed, leaking sockets and leaving them in CLOSE_WAIT/FIN_WAIT_2 state.

### Other fixes

- Added missing `p_Logger != null` guards on three unprotected call sites
- Changed `p_ConnectionsCounter++/--` to `Interlocked.Increment/Decrement` for thread safety

## Test plan

- [x] CI builds successfully
- [x] Integration test: IIS + Lucee 7 + patched DLLs serves pages through BonCode (port 80)
- [x] Integration test: Tomcat direct (port 8888) still works
- [ ] Tester with scheduled tasks running at midnight confirms no more hangs
- [ ] Tester with idle connections confirms no more 502 on first request